### PR TITLE
Ability to override expiry days and proxy via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ These configuration options are available for the plugin:
 
 ![config options](./img/configuration.png?s=200)
 
-- Minimum Certificate Validity in Days: the threshold when the plugin should create an alert for a certificate that is about to expire
+- Minimum Certificate Validity in Days: the threshold when the plugin should create an alert for a certificate that is about to expire. Please see [Configuration via Tags](#configuration-via-tags) how to override proxy settings per synthetic monitor.
 - Time interval for checks: the interval at which the plugin should check certificates (it makes no sense to check every minute). Please note that the interval is calculated based on the current time and not the configuration time. E.g. "every 15 minutes" will mean the check is performed at the full hour, 15 past, 30 past, 45 past the full hour. Likewise every "2 hours" means at 2am, 4am, ... 12am. 
 - Select Synthetic Monitors by Tag: Limit the certificate check to synthetic monitors that are tagged with this tag. Only one tag is allowed.
 - Consider disabled monitors in checks: when selected the plugin will also perform SSL certificate checks for monitors that are disabled. You can use this option to avoid DEM unit consumption for synthetic checks and still validate certificates.
 - Report certificate expiry days as metrics: when enabled the plugin will report the measured expiry days per monitor as metric (metric key is ```threesixty-perf.certificates.daystoexpiry```). Note that custom metrics will consume DDU licenses.
 - Dynatrace Tenant UUID to report to: this is the tenant UUID that the plugin will get synthetic monitors from and report to (using the configured API token). Typically this will be the same tenant as the plugin is configured for. Only provide the tenant ID, not the full hostname.
 - Dynatrace API token: the API token with the permissions mentioned above
-- Proxy and proxy port: when specified the plugin will use the proxy to connect to the target hosts. This is especially helpful for restricted environments where the Active Gate doesn't have full internet access. 
+- Proxy and proxy port: when specified the plugin will use the proxy to connect to the target hosts. This is especially helpful for restricted environments where the Active Gate doesn't have full internet access. Please see [Configuration via Tags](#configuration-via-tags) how to override proxy settings per synthetic monitor.
 
 ### Problem Events
 When the a certificate check fails the plugin will post a problem opening event to Dynatrace (and update is consequently), which contains information about the expiry time and additional certificate information.
@@ -39,5 +39,14 @@ As the problem is thereafter updated regulary by the plugin the expiry informati
 
 ![config options](./img/problem.png?s=200)
 
-## Further Options
-As the plugin as acces to the full certificate it would be rather easy to perform also other checks (e.g. hostname matches). This might be a future addition.
+## Configuration via Tags
+To add more configuration flexibility it is possible to pass per-site settings to the plugin via tags on the Synthetic monitor. (e.g this enables non-admin Dynatrace users with no access to global plugin configuration to somewhat customize their checks). Currently you can override the expiry duration and the proxy configuration that should be used for a SSL endpoint by providing these two tags (case sensitive):
+
+- Key: "SSLCheckExpire" Value: <Number - days to warn before certificate expiration>
+- Key: "SSLCheckProxy" Value: <hostname>:<port> - proxy and port to use for establishing SSL connection
+
+
+## Donations
+I'm developing this plugin in my spare time. If you like this Dynatrace Active Gate Plugin or if it saves you some time and effort. I'm happy to receive a small donation.
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RUZP3LCKH56CU)

--- a/certcheck_plugin/plugin.json
+++ b/certcheck_plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "custom.remote.python.certcheck",
     "metricGroup": "tech.ssl",
-    "version": "1.15",
+    "version": "1.16",
     "experimentalMinVersion": "0.99",
     "productiveMinVersion": "1.0",
     "type": "python",


### PR DESCRIPTION
You can now override the global plugin configuration settings for minimum certificate validity and the proxy that should be used to perform the check