### PR TITLE
Reopening of Problems after manual close

### DIFF
--- a/certcheck_plugin/certcheck.py
+++ b/certcheck_plugin/certcheck.py
@@ -113,7 +113,7 @@ class CertificateCheckPlugin(RemoteBasePlugin):
 
     def isProblemOpen(self,entityId):
         apiurl = "/api/v2/problems"
-        parameters = {"problemSelector": "impactedEntities({}),status(OPEN),text({})".format(entityId, PROBLEM_TITLE), "from": "now-{}m".format(self.refreshcheck)}
+        parameters = {"problemSelector": "impactedEntities(\"{}\"),status(\"OPEN\"),text(\"{}\")".format(entityId, PROBLEM_TITLE), "from": "now-{}m".format(self.refreshcheck)}
         headers = {"Authorization": "Api-Token {}".format(self.apitoken)}
         url = self.server + apiurl
         try:
@@ -133,7 +133,7 @@ class CertificateCheckPlugin(RemoteBasePlugin):
         # so we check the open problem AND the event if no open problem exists we do not refresh the event but let it expire, once it expires a new problem will be opened
 
         apiurl = "/api/v2/events"
-        parameters = {"eventSelector": "eventType(ERROR_EVENT),status(OPEN),property.dt.event.source({})".format(self.source), "from": "now-{}m".format(self.refreshcheck)}
+        parameters = {"eventSelector": "eventType(\"ERROR_EVENT\"),status(\"OPEN\"),property.dt.event.source(\"{}\")".format(self.source), "from": "now-{}m".format(self.refreshcheck)}
         headers = {"Authorization": "Api-Token {}".format(self.apitoken)}
         url = self.server + apiurl
 
@@ -151,8 +151,8 @@ class CertificateCheckPlugin(RemoteBasePlugin):
                     # for every open event there should also be an open problem (if not then it has been closed manually and we should reopen it)
                     entityId = event["entityId"]["entityId"]["id"]
                     if self.isProblemOpen(entityId):
-                        logger.info("A problem for {} is already open for {} minutes".format(event["entityName"], diff_min))
-                        monitors.update({event["entityId"]:event["entityName"]})
+                        logger.info("A problem for {} is already open for {} minutes".format(event["entityId"]["name"], diff_min))
+                        monitors.update({event["entityId"]["entityId"]["id"]:event["entityId"]["name"]})
             else:
                 logger.error("Getting events returned {}: {}".format(response.status_code,result))
         except Exception as e:

--- a/certcheck_plugin/certcheck.py
+++ b/certcheck_plugin/certcheck.py
@@ -164,35 +164,6 @@ class CertificateCheckPlugin(RemoteBasePlugin):
 
         return monitors
 
-        '''
-        apiurl = "/api/v1/events"
-        parameters = {"eventType": "ERROR_EVENT", "relativeTime": "10mins"}
-        headers = {"Authorization": "Api-Token {}".format(self.apitoken)}
-        url = self.server + apiurl
-
-        monitors = {}
-        try:
-            response = requests.get(url, params=parameters, headers=headers, verify=False)
-            result = response.json()
-            if response.status_code == requests.codes.ok:
-                for event in result["events"]:
-                    if "OPEN" in event["eventStatus"] and self.source in event["source"]:
-                        start_TS =  int(event["startTime"])
-                        now = datetime.now()
-                        now_TS = int(datetime.timestamp(now)*1000)
-                        diff_min = int((now_TS - start_TS)/1000/60)
-                        logger.info("A problem for {} is already open for {} minutes".format(event["entityName"], diff_min))
-
-                        #if diff_min > self.problemtimeout - self.refreshcheck*2:
-                        monitors.update({event["entityId"]:event["entityName"]})
-            else:
-                logger.error("Getting events returned {}: {}".format(response.status_code,result))
-        except Exception as e:
-            logger.error("Error while getting open events {}: {}".format(url, e))
-
-        return monitors
-        '''
-
     def getSyntheticMonitors(self):
         apiurl = "/api/v1/synthetic/monitors"
         parameters = {"tag":self.tag, "enabled":"true"}

--- a/certcheck_plugin/certcheck.py
+++ b/certcheck_plugin/certcheck.py
@@ -59,7 +59,7 @@ class CertificateCheckPlugin(RemoteBasePlugin):
         self.server = "https://localhost:9999/e/"+self.tenant   # this is an active gate plugin so it can call the DT API on localhost
         self.proxy_addr = self.config["proxy_addr"]
         self.proxy_port = self.config["proxy_port"]
-        self.problemtimeout = 120
+        self.problemtimeout = 10
         self.refreshcheck = 5
         self.source = "{} (Endpoint config: {})".format(SOURCE,self.activation.endpoint_name)
 
@@ -120,7 +120,11 @@ class CertificateCheckPlugin(RemoteBasePlugin):
             response = requests.get(url, params=parameters, headers=headers, verify=False)
             result = response.json()
             if response.status_code == requests.codes.ok:
-                return len(result["problems"]) > 0
+                if len(result["problems"]) > 0:
+                    logger.info("{} open problems for {}".format(len(result["problems"]),entityId))
+                    return True
+                else:
+                    return False
         except Exception as e:
             logger.error("Error while getting open problem status {}: {}".format(url, e))
 

--- a/certcheck_plugin/plugin.json
+++ b/certcheck_plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "custom.remote.python.certcheck",
     "metricGroup": "tech.ssl",
-    "version": "1.17.4",
+    "version": "1.18",
     "experimentalMinVersion": "0.99",
     "productiveMinVersion": "1.0",
     "type": "python",

--- a/certcheck_plugin/plugin.json
+++ b/certcheck_plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "custom.remote.python.certcheck",
     "metricGroup": "tech.ssl",
-    "version": "1.16",
+    "version": "1.17",
     "experimentalMinVersion": "0.99",
     "productiveMinVersion": "1.0",
     "type": "python",

--- a/certcheck_plugin/plugin.json
+++ b/certcheck_plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "custom.remote.python.certcheck",
     "metricGroup": "tech.ssl",
-    "version": "1.17",
+    "version": "1.17.4",
     "experimentalMinVersion": "0.99",
     "productiveMinVersion": "1.0",
     "type": "python",


### PR DESCRIPTION
When a created SSL expiry problem was manually closed instead of fixed through certificate renewal, the plugin checl didn't reopen a new problem if the certificate didn't get fixed.
This was due to the error event being constantly refreshed and thus didn't trigger a new problem opening.
Now the error events use a lower timeout which is only refreshed if a open problem exists. So if the problem gets manually closed the event also times out and a subsequent check will trigger a new problem.

Also, the problem and event APIs for these checks have be switched to APIv2. this means currently the used api token also needs these additional scopes (v2):
- events.read
- problems.read