### PR TITLE
Allow the use of inactive monitors

### DIFF
--- a/certcheck_plugin/certcheck.py
+++ b/certcheck_plugin/certcheck.py
@@ -178,12 +178,14 @@ class CertificateCheckPlugin(RemoteBasePlugin):
         url = self.server + apiurl + query
 
         monitors = {}
+        inactiveMonitors = {} # identify monitors that have a old last seen timestamp
         try:
             response = requests.get(url, headers=headers, verify=False)
             result = response.json()
             if response.status_code == requests.codes.ok:
                 for monitor in result["monitors"]:
                     monitors.update({monitor["entityId"]:monitor["name"]})
+                    if monitor["lastSeen"]
             else:
                 logger.error("Getting monitors returned {}: {}".format(response.status_code,result))
         except:

--- a/certcheck_plugin/plugin.json
+++ b/certcheck_plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "custom.remote.python.certcheck",
     "metricGroup": "tech.ssl",
-    "version": "1.19",
+    "version": "1.26",
     "experimentalMinVersion": "0.99",
     "productiveMinVersion": "1.0",
     "type": "python",


### PR DESCRIPTION
Dynatrace introduced limitations where inactive monitors can't be used to post events/problems to.
This version avoids this problem by "touching" the monitor automatically so that it can be used to post events to.
Fixes: https://github.com/360Performance/dynatrace-plugin-certcheck/issues/13